### PR TITLE
【未レビュー】表示改善

### DIFF
--- a/src/components/common/DropdownMenu.tsx
+++ b/src/components/common/DropdownMenu.tsx
@@ -39,6 +39,8 @@ interface DropdownMenuProps {
   menuClassName?: string
   /** メニューアイテムの文字サイズ */
   fontSize?: 'sm' | 'base' | 'lg'
+  /** メニューアイテムの高さ */
+  itemHeight?: 'sm' | 'base' | 'lg'
 }
 
 export default function DropdownMenu({
@@ -54,7 +56,8 @@ export default function DropdownMenu({
   zIndex = 10,
   triggerClassName = '',
   menuClassName = '',
-  fontSize = 'sm'
+  fontSize = 'sm',
+  itemHeight = 'sm'
 }: DropdownMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null)
 
@@ -108,6 +111,17 @@ export default function DropdownMenu({
         return 'text-lg'
       default:
         return 'text-sm'
+    }
+  }
+
+  const getItemHeight = () => {
+    switch (itemHeight) {
+      case 'base':
+        return 'py-3'
+      case 'lg':
+        return 'py-4'
+      default:
+        return 'py-2'
     }
   }
 
@@ -165,7 +179,7 @@ export default function DropdownMenu({
                 onClick={(e) => handleItemClick(item, e)}
                 disabled={isDisabled}
                 className={`
-                  w-full px-3 py-2 text-left ${getFontSize()} flex items-center gap-2 transition-colors
+                  w-full px-3 ${getItemHeight()} text-left ${getFontSize()} flex items-center gap-2 transition-colors
                   ${isDisabled 
                     ? 'text-gray-400 cursor-not-allowed' 
                     : isDanger 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -165,6 +165,8 @@ const Header = memo(function Header() {
                 position="bottom-right"
                 width="w-48"
                 zIndex={60}
+                fontSize="base"
+                itemHeight="base"
                 customTrigger={
                   getDisplayIconUrl ? (
                     <Image
@@ -216,6 +218,8 @@ const Header = memo(function Header() {
                 position="bottom-right"
                 width="w-48"
                 zIndex={60}
+                fontSize="base"
+                itemHeight="base"
                 customTrigger={
                   getDisplayIconUrl ? (
                     <Image

--- a/src/components/phrase/PhraseItem.tsx
+++ b/src/components/phrase/PhraseItem.tsx
@@ -70,6 +70,7 @@ const PhraseItem = memo(({
             triggerSize="lg"
             width="w-36"
             fontSize="base"
+            itemHeight="base"
             items={[
               {
                 id: 'explanation',

--- a/src/components/speak/SpeakPractice.tsx
+++ b/src/components/speak/SpeakPractice.tsx
@@ -136,7 +136,9 @@ export default function SpeakPractice({
         
         {/* 学習言語のフレーズ（メイン表示） */}
         <div className="mb-2">
-          <div className="text-base sm:text-lg md:text-xl font-medium text-gray-900 break-words leading-relaxed">
+          <div className={`text-base sm:text-lg md:text-xl font-medium text-gray-900 break-words leading-relaxed ${
+            phrase?.explanation && onExplanation ? 'pr-8' : ''
+          }`}>
             {phrase.original}
           </div>
         </div>


### PR DESCRIPTION
- Speak画面のExplanationボタンとフレーズが被らないように修正
- ヘッダーのユーザーアイコンを押下したときに表示されるリストのサイズを拡大